### PR TITLE
Use proper MarkDown for the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ Add users
 
 Setup SSH:
 
-    cd /docker_data/git && mkdir .ssh && chown -R 987 .ssh && chmod -R 700 .ssh && touch .ssh/authorized_keys
+    cd /docker_data/git
+    mkdir .ssh
+    chown -R 987 .ssh
+    chmod -R 700 .ssh
+    touch .ssh/authorized_keys
 
 Add user public keys to `.ssh/authorized_keys` just like you would do for 'normal' SSH.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Setup SSH:
 
     cd /docker_data/git
     mkdir .ssh
-    chown -R 987 .ssh
+    chown -R 987:987 .ssh
     chmod -R 700 .ssh
     touch .ssh/authorized_keys
 

--- a/README.md
+++ b/README.md
@@ -3,56 +3,60 @@ git-ssh-server
 
 A minimal GIT server.
 
-Build instructions:
-===================
+Build instructions
+==================
 
-git clone https://github.com/unixtastic/git-ssh-server
+    git clone https://github.com/unixtastic/git-ssh-server
+    docker build -t 'unixtastic/git-ssh-server' .
 
-docker build -t 'unixtastic/git-ssh-server' .
-
-Usage instructions:
-===================
+Usage instructions
+==================
 
 To run this first create a data directory on your docker host to hold git data, ssh authentication,
 and possibly git-shell-commands.
 
-mkdir /docker_data/git
+    mkdir /docker_data/git
 
 Run the container.
 
-docker run -d -p 2222:22 -v /docker_data/git:/git unixtastic/git-ssh-server
+    docker run -d -p 2222:22 -v /docker_data/git:/git unixtastic/git-ssh-server
 
 You may substitute '2222' with any port number of your choosing.
 
-To add users:
+Add users
+---------
 
 Setup SSH:
-cd /docker_data/git && mkdir .ssh && chown -R 987 .ssh && chmod -R 700 .ssh && touch .ssh/authorized_keys
 
-Add user public keys to .ssh/authorized_keys just like you would do for 'normal' SSH.
+    cd /docker_data/git && mkdir .ssh && chown -R 987 .ssh && chmod -R 700 .ssh && touch .ssh/authorized_keys
 
-touch /docker_data/git/.hushlogin to prevent login banners that can confuse git.
+Add user public keys to `.ssh/authorized_keys` just like you would do for 'normal' SSH.
 
-To setup repos:
+    touch /docker_data/git/.hushlogin to prevent login banners that can confuse git.
 
-mkdir /docker_data/git/mynewproject.git
-cd /docker_data/git/mynewproject.git
-git --bare init
-chown -R 987:987 .
+Setup repos
+-----------
+
+    mkdir /docker_data/git/mynewproject.git
+    cd /docker_data/git/mynewproject.git
+    git --bare init
+    chown -R 987:987 .
 
 Clone the repo from a client:
-git clone ssh://git@myserver:2222/git/mynewproject.git
 
-To setup git-shell-commands:
+    git clone ssh://git@myserver:2222/git/mynewproject.git
 
-mkdir /docker_data/git/git-shell-commands
-chown 987:987 /docker_data/git/git-shell-commands
-chmod 700 /docker_data/git/git-shell-commands
+Setup git-shell-commands
+------------------------
+
+    mkdir /docker_data/git/git-shell-commands
+    chown 987:987 /docker_data/git/git-shell-commands
+    chmod 700 /docker_data/git/git-shell-commands
+
 Add your commands to the above directory. You might want to start with list, which
-you can find under /usr/share/doc on most git client machines.
+you can find under `/usr/share/doc` on most git client machines.
 
-Notes:
-======
+Notes
+=====
 
 The SSH host keys are generated at the first run of each new container. This will confuse some git clients and really should be changed.
-


### PR DESCRIPTION
The Readme doesn't properly mark code, which makes it difficult to read
from its main page in github.  Use code blocks, code syntax and
secondary sections to improve readability.
